### PR TITLE
refactor(config): Supprime Swagger

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/serve-static": "^5.0.3",
-    "@nestjs/swagger": "^11.1.6",
     "@prisma/client": "^6.7.0",
     "@types/multer": "^1.4.12",
     "bcryptjs": "^3.0.2",

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -17,7 +17,6 @@ import { AuthGuard } from './guards/auth.guard';
 import { AdminRoleGuard } from './guards/admin-role.guard';
 import { GetUser } from './decorators/get-user.decorator';
 import { JwtPayload } from './interfaces/jwt-payload.interface';
-import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('admin')
 export class AdminController {
@@ -50,7 +49,6 @@ export class AdminController {
     return this.adminService.login(loginDto.email, loginDto.password);
   }
 
-  @ApiBearerAuth('jwt')
   @UseGuards(AuthGuard, AdminRoleGuard)
   @Patch(':id')
   async update(

--- a/src/admin/dto/update-admin.dto.ts
+++ b/src/admin/dto/update-admin.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/mapped-types';
 import { CreateAdminDto } from './create-admin.dto';
 
 export class UpdateAdminDto extends PartialType(CreateAdminDto) {}

--- a/src/badge-contract/badge-status.controller.ts
+++ b/src/badge-contract/badge-status.controller.ts
@@ -15,14 +15,12 @@ import { CreateBadgeStatusDto } from './dto/create-badge-status.dto';
 import { UpdateBadgeStatusDto } from './dto/update-badge-status.dto';
 import { AuthGuard } from '../admin/guards/auth.guard';
 import { AdminRoleGuard } from '../admin/guards/admin-role.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('badge-status')
 @UseGuards(AuthGuard, AdminRoleGuard)
 export class BadgeStatusController {
   constructor(private readonly badgeStatusService: BadgeStatusService) {}
 
-  @ApiBearerAuth('jwt')
   @Post()
   @HttpCode(HttpStatus.CREATED)
   create(@Body() createBadgeStatusDto: CreateBadgeStatusDto) {

--- a/src/badge-contract/contract-type.controller.ts
+++ b/src/badge-contract/contract-type.controller.ts
@@ -15,14 +15,12 @@ import { CreateContractTypeDto } from './dto/create-contract-type.dto';
 import { UpdateContractTypeDto } from './dto/update-contract-type.dto';
 import { AuthGuard } from '../admin/guards/auth.guard';
 import { AdminRoleGuard } from '../admin/guards/admin-role.guard';
-import { ApiBearerAuth } from '@nestjs/swagger';
 
 @Controller('contract-type')
 @UseGuards(AuthGuard, AdminRoleGuard)
 export class ContractTypeController {
   constructor(private readonly contractTypeService: ContractTypeService) {}
 
-  @ApiBearerAuth('jwt')
   @Post()
   @HttpCode(HttpStatus.CREATED)
   create(@Body() createContractTypeDto: CreateContractTypeDto) {

--- a/src/badge-contract/dto/update-badge-status.dto.ts
+++ b/src/badge-contract/dto/update-badge-status.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/mapped-types';
 import { CreateBadgeStatusDto } from './create-badge-status.dto';
 
 export class UpdateBadgeStatusDto extends PartialType(CreateBadgeStatusDto) {}

--- a/src/badge-contract/dto/update-contract-type.dto.ts
+++ b/src/badge-contract/dto/update-contract-type.dto.ts
@@ -1,4 +1,4 @@
-import { PartialType } from '@nestjs/swagger';
+import { PartialType } from '@nestjs/mapped-types';
 import { CreateContractTypeDto } from './create-contract-type.dto';
 
 export class UpdateContractTypeDto extends PartialType(CreateContractTypeDto) {}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,4 @@
 import { NestFactory } from '@nestjs/core';
-import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
@@ -13,29 +12,6 @@ async function bootstrap() {
     origin: frontendUrl,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     credentials: true,
-  });
-
-  const config = new DocumentBuilder()
-    .setTitle('API du Portfolio')
-    .setDescription('Api du portfolio de <NAME>')
-    .setVersion('1.0')
-    .addTag('djoudj')
-    .addBearerAuth(
-      {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'Authorization',
-        in: 'header',
-      },
-      'jwt',
-    )
-    .build();
-  const documentFactory = () => SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, documentFactory(), {
-    swaggerOptions: {
-      persistAuthorization: true,
-    },
   });
 
   await app.listen(process.env.PORT ?? 3000);


### PR DESCRIPTION
- Supprime l'intégration de Swagger dans le projet, y compris les décorateurs `@ApiBearerAuth` et la configuration Swagger dans `main.ts`.
- Corrige les imports pour utiliser `@nestjs/mapped-types` au lieu de `@nestjs/swagger`.
- Mis à jour les dépendances en retirant `@nestjs/swagger` de `package.json`.